### PR TITLE
Add drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,39 @@
+pipeline:
+
+  build_image:
+    image: docker:18.03.0-ce
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - docker build -t drone-docker:$${DRONE_COMMIT_SHA} .
+    when:
+      event: [push, tag]
+
+  latest_image_to_quay:
+    image: docker:18.03.0-ce
+    secrets:
+      - docker_password
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - docker login -u="ukhomeofficedigital+drone_docker_overlay" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag drone-docker:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/drone-docker:$${DRONE_COMMIT_SHA}
+      - docker tag drone-docker:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/drone-docker:latest
+      - docker push quay.io/ukhomeofficedigital/drone-docker:$${DRONE_COMMIT_SHA}
+      - docker push quay.io/ukhomeofficedigital/drone-docker:latest
+    when:
+      event: push
+      branch: master
+
+  tag_image_to_quay:
+    image: docker:18.03.0-ce
+    secrets:
+      - docker_password
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - docker login -u="ukhomeofficedigital+drone_docker_overlay" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag drone-docker:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/drone-docker:$${DRONE_TAG}
+      - docker push quay.io/ukhomeofficedigital/drone-docker:$${DRONE_TAG}
+    when:
+      event: tag

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Overlay of hub.docker.com/r/plugins/docker that sets ukhomeoffice drone docker dind
 
-The main reason this had to exist is because [drone looks for an exact string match of `plugins/docker`](https://github.com/drone/drone/blob/923de1c4f20ea596bd17d8e4c7fad1e5f192fa87/cmd/drone-server/server.go#L111) and tries to enable privilaged which isn't allowed in ACP.
+The main reason this had to exist is because [drone looks for an exact string match of `plugins/docker`](https://github.com/drone/drone/blob/923de1c4f20ea596bd17d8e4c7fad1e5f192fa87/cmd/drone-server/server.go#L111) and tries to enable privileged which isn't allowed in ACP.
 You can also work around it by specifying the full url and specifying the env var of the docker host, the same as I've done in the [Dockerfile](./Dockerfile) here
 
 ## Example Usage


### PR DESCRIPTION
This is because we want the drone-docker plugin images to be pulled from Quay rather than Docker Hub. Another PR to amend the docs will follow.